### PR TITLE
Ajout pgadmin4 - client postgres online

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,18 @@
 
 * `sbt run` à la racine du projet  
 * docker  + docker-compose installé + `docker-compose up`  à la racine du projet  
-* Client PostGreSQL
+* Accès pgAdmin : http://localhost:5050
+    * login : pgadmin4@pgadmin.org - password : admin
+    * Au premier lancement, enregitrer la base
+        * clic droit sur serveur --> create / server
+            * Name : ce que vous voulez, workshop par exemple
+            * connection : 
+                * host : postgres
+                * username : docker
+                * password : docker
+                * save password : true
+
+*Si vous voulez utiliser votre propre client PostGreSQL, commentez les lignes du docker-compose concernant pgAdmin, cela vous sauvegardera des ressources ;)*
 
 Les tables nécessaires au workshop seront automatiquement créées lors du `docker-compose up`
 
@@ -17,3 +28,4 @@ Nous allons réaliser lors de ce workshop, un trello eventsourcé :
 ![](./public/images/trello-event-source.png)
 
 [Workshop](1-workshop.md)
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,13 @@
+# pgadmin 4
+pgadmin:
+    # login : pgadmin4@pgadmin.org - password : admin
+    image: fenglc/pgadmin4:2.1-python2.7-alpine
+    container_name: pgadmin4_workshop
+    links:
+      - postgres:postgres
+    ports:
+      - 5050:5050
+# database
 postgres:
   image: postgres:latest
   container_name: postgres_workshop


### PR DESCRIPTION
Ajout du serveur / client online pgadmin4 comme cela, pas besoin d'installer de client postgreSQL en local sur les postes.